### PR TITLE
Minor printing fixes to make sure that the emitted proof script is valid

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -36,8 +36,10 @@ let generate_proof_script coq_verbose deps old_program new_program  coq_dir coq_
     Proof_generator.Proof_context.init
       ~compilation_context:env ~old_proof ~new_proof_base
       ~alignment ~concrete ~ctx in
+  let new_proof =
+    (new_proof_base ^ "\n" ^ Proof_generator.Generator.generate ~logical_mappings:[("s", "l")] ctx new_program) in
   Bos.OS.File.write Fpath.(coq_dir / new_proof_name)
-    (Proof_generator.Generator.generate ~logical_mappings:[("s", "l")] ctx new_program)
+    new_proof
   |> Result.get_exn
 
 

--- a/test/test_seq_to_array.ml
+++ b/test/test_seq_to_array.ml
@@ -1,0 +1,10 @@
+module T = Testing_utils.Make (struct let name = "seq_to_array" end)
+
+let () =
+  T.add_test "seq_to_array"
+    (Testing_utils.sisyphus_runs_on
+       ~path:"../resources/seq_to_array"
+       ~coq_name:"Proofs")
+
+let () =
+    Testing_utils.run "seq_to_array_test"


### PR DESCRIPTION
There's a small bug in the Coq pretty-printing API wherein if we try and pretty print a Coq AST directly through the pretty printing API, it will actually fail to emit a parseable term.

To fix this, the proof context now tracks explicitly the list of all strings that are sent to the Coq context, accounting for cancellations and such. At the end, this list of strings is just concatenated back together to retrieve the intended proof script.

As such, this PR makes it so that the alcotest test (executed by running `dune test`) now passes.

- We're all green BOYS